### PR TITLE
Change casperjs cmd arguments

### DIFF
--- a/src/main/java/com/github/raonifn/casperjs/junit/CasperExecutor.java
+++ b/src/main/java/com/github/raonifn/casperjs/junit/CasperExecutor.java
@@ -37,6 +37,9 @@ public class CasperExecutor {
 	public int executeCasper(String pathToFile, String... arguments) {
 		Runtime runtime = Runtime.getRuntime();
 		File dir = new File(pathToFile).getParentFile();
+		if(!dir.exists()){
+			throw new IllegalArgumentException(String.format("Parent of '%s' does not exist", pathToFile));
+		}
 
 		String phantomjs = System.getProperty("phantomjs.executable");
 		if (phantomjs != null) {
@@ -44,7 +47,7 @@ public class CasperExecutor {
 		}
 
 		try {
-			Process exec = runtime.exec(mountCommandLine(pathToFile, arguments), mountEnv(), dir);
+			Process exec = runtime.exec(mountCommandLine(arguments), mountEnv(), dir);
 
 			if (!outs.isEmpty()) {
 				Pipe pipe = new Pipe(exec.getInputStream(), outs);
@@ -65,10 +68,9 @@ public class CasperExecutor {
 		}
 	}
 
-	private String[] mountCommandLine(String pathToFile, String[] arguments) {
-		List<String> cmd = new ArrayList<String>(arguments.length + 2);
+	private String[] mountCommandLine(String[] arguments) {
+		List<String> cmd = new ArrayList<String>(arguments.length + 1);
 		cmd.add(casperPath);
-		cmd.add(pathToFile);
 		cmd.addAll(Arrays.asList(arguments));
 		return cmd.toArray(new String[cmd.size()]);
 	}

--- a/src/main/java/com/github/raonifn/casperjs/junit/CasperJSTestCase.java
+++ b/src/main/java/com/github/raonifn/casperjs/junit/CasperJSTestCase.java
@@ -1,10 +1,6 @@
 package com.github.raonifn.casperjs.junit;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.URL;
 import java.util.Map;
 
@@ -54,7 +50,7 @@ public class CasperJSTestCase {
 				executor.pipeOut(out);
 				executor.pipeOut(System.out);
 				String fileName = path.replaceAll(".*\\/(.*)", "$1");
-				int result = executor.executeCasper(path, "--script-name= " + fileName);
+				int result = executor.executeCasper(path, "test", new File(path).getAbsolutePath(), "--fail-fast=true");
 				if (result == 0) {
 					notifier.fireTestFinished(description);
 					return;


### PR DESCRIPTION
Old way was not even working on Windows systems because it could not find given .test.js file.
Moreover, casperjs is usually intended for use as `casperjs test <filename>` as it is a multi purpose application.
Finally, added `--fail-fast=true` so it became trivial to implement exit status correctly. This can be undesired for some users. My suggestion would be to get cmd parameters from an annotation.
